### PR TITLE
refactor: clarify component names

### DIFF
--- a/src/cnd-app/about-us/index.jsx
+++ b/src/cnd-app/about-us/index.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Navbar12 } from "../../components/common/Navbar12";
+import { MainNavbar } from "../../components/common/MainNavbar";
 import { Header47 } from "./components/Header47";
 import { Layout41 } from "./components/Layout41";
 import { Layout369 } from "./components/Layout369";
@@ -13,7 +13,7 @@ import { Footer2 } from "../../components/common/Footer2";
 export default function AboutUs() {
   return (
     <div className="min-h-screen bg-white">
-      <Navbar12 />
+      <MainNavbar />
       <br />
       <Header47 />
       {/* <Layout41 /> */}

--- a/src/cnd-app/contact-us/components/FaqSection.jsx
+++ b/src/cnd-app/contact-us/components/FaqSection.jsx
@@ -8,7 +8,7 @@ import {
   } from "@relume_io/relume-ui";
 import { RxPlus } from "react-icons/rx";
 
-const Faq4 = (props) => {
+const FaqSection = (props) => {
   const {
     heading,
     description,
@@ -16,7 +16,7 @@ const Faq4 = (props) => {
     footerHeading,
     footerDescription,
   } = {
-    ...Faq4Defaults,
+    ...FaqSectionDefaults,
     ...props,
   };
 
@@ -101,7 +101,7 @@ const Faq4 = (props) => {
 
 
 
-const Faq4Defaults = {
+const FaqSectionDefaults = {
   heading: "FAQs",
   description:
     "Here are some common questions we receive from our users about our service.",
@@ -454,4 +454,4 @@ const Faq4Defaults = {
 };
 
 
-export { Faq4, Faq4Defaults };
+export { FaqSection, FaqSectionDefaults };

--- a/src/cnd-app/contact-us/index.jsx
+++ b/src/cnd-app/contact-us/index.jsx
@@ -1,24 +1,24 @@
 "use client";
 
 import React from "react";
-import { Navbar12 } from "../../components/common/Navbar12";
+import { MainNavbar } from "../../components/common/MainNavbar";
 import { Header47 } from "./components/Header47";
 import { Contact13 } from "./components/Contact13";
 import { Contact2 } from "./components/Contact2";
 import { Contact14 } from "./components/Contact14";
-import { Faq4 } from "./components/Faq4";
+import { FaqSection } from "./components/FaqSection";
 import { Footer2 } from "../../components/common/Footer2";
 
 export default function ContactUs() {
   return (
     <div className="min-h-screen bg-white">
-      <Navbar12 />
+      <MainNavbar />
       <br />
       <br />
       {/* <Header47 /> */}
       {/* <Contact2 /> */}
       {/* <Contact14 /> */}
-      <Faq4 />
+      <FaqSection />
       <Contact13 />
       <Footer2 />
     </div>

--- a/src/cnd-app/for-drivers/components/SmartChargingHeader.jsx
+++ b/src/cnd-app/for-drivers/components/SmartChargingHeader.jsx
@@ -2,8 +2,9 @@
 
 import { Button } from "@relume_io/relume-ui";
 import React, { useEffect } from "react";
+import AppStoreButton from "../../../assets/Buttons/AppStoreButton";
 
-export function Header47() {
+export function SmartChargingHeader() {
   useEffect(() => {
     // Add fade-in animation to elements when component mounts
     const heading = document.querySelector('.header-heading');
@@ -20,38 +21,47 @@ export function Header47() {
       <div className="container">
         <div className="flex flex-col gap-5 md:flex-row md:gap-12 lg:gap-20">
           <div className="w-full max-w-lg">
-            <p className="mb-3 font-semibold md:mb-4 text-accent">Host Benefits</p>
+            <p className="mb-3 font-semibold md:mb-4 text-accent">Savings</p>
             <h1 className="header-heading text-6xl font-bold md:text-7xl lg:text-8xl">
-              Share Your Charger, Earn Money
+              Charge Smartly Today
             </h1>
           </div>
           <div className="w-full max-w-lg">
             <p className="header-description md:text-md text-french-gray">
-              Turn your home EV charger into a source of income by sharing it with drivers in your area. 
-              Our platform makes it easy to list your charger, set your rates, and manage bookings.
+              Discover the ease of charging your electric vehicle at home with
+              our innovative platform. Enjoy significant savings, enhanced
+              security, and unparalleled convenience by using a host's charger
+              instead of costly public options.
             </p>
+            
+            {/* App Store Download Button */}
+            <div className="mt-6 mb-4">
+              <AppStoreButton 
+                href="https://apps.apple.com/your-app-store-link" 
+                className="inline-block"
+              />
+            </div>
+            
             <div className="header-buttons mt-6 flex justify-center flex-wrap gap-4 md:mt-8">
               <Button 
-                title="Become a Host"
+                title="Learn More"
                 className="bg-accent hover:bg-malachite text-governor-bay font-bold rounded-lg transition-all duration-300 hover:shadow-lg hover:-translate-y-1"
-                onClick={() => window.open("https://mailchi.mp/d3662d8474be/chargenextdoor", "_blank")}
-              >
-                Become a Host
-              </Button>
-            
-              <Button 
-                title="Learn More" 
-                variant="secondary"
                 onClick={() => window.location.href = "/contact-us"}
-                className="bg-transparent text-white font-bold border-2 border-accent rounded-lg transition-all duration-300 hover:bg-accent/10 hover:shadow-lg hover:-translate-y-1"
               >
                 Learn More
               </Button>
-               
+              <Button 
+                title="Sign Up" 
+                variant="secondary"
+                className="bg-transparent text-white font-bold border-2 border-accent rounded-lg transition-all duration-300 hover:bg-accent/10 hover:shadow-lg hover:-translate-y-1"
+                onClick={() => window.open("https://mailchi.mp/d3662d8474be/chargenextdoor", "_blank")}
+              >
+                Sign Up
+              </Button>
             </div>
           </div>
         </div>
       </div>
     </section>
   );
-} 
+}

--- a/src/cnd-app/for-drivers/index.jsx
+++ b/src/cnd-app/for-drivers/index.jsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React from "react";
-import { Navbar12 } from "../../components/common/Navbar12";
-import { Header47 } from "./components/Header47";
+import { MainNavbar } from "../../components/common/MainNavbar";
+import { SmartChargingHeader } from "./components/SmartChargingHeader";
 import { Layout3 } from "./components/Layout3";
 import { Layout12 } from "./components/Layout12";
 import { Layout3_1 } from "./components/Layout3_1";
@@ -12,8 +12,8 @@ import { Footer2 } from "../../components/common/Footer2";
 export default function ForDrivers() {
   return (
     <div className="min-h-screen bg-white">
-      <Navbar12 />
-      <Header47 />
+      <MainNavbar />
+      <SmartChargingHeader />
       <Layout3 />
       <Layout12 />
       <Layout3_1 />

--- a/src/cnd-app/for-hosts/components/HostHeroHeader.jsx
+++ b/src/cnd-app/for-hosts/components/HostHeroHeader.jsx
@@ -2,9 +2,8 @@
 
 import { Button } from "@relume_io/relume-ui";
 import React, { useEffect } from "react";
-import AppStoreButton from "../../../assets/Buttons/AppStoreButton";
 
-export function Header47() {
+export function HostHeroHeader() {
   useEffect(() => {
     // Add fade-in animation to elements when component mounts
     const heading = document.querySelector('.header-heading');
@@ -21,47 +20,38 @@ export function Header47() {
       <div className="container">
         <div className="flex flex-col gap-5 md:flex-row md:gap-12 lg:gap-20">
           <div className="w-full max-w-lg">
-            <p className="mb-3 font-semibold md:mb-4 text-accent">Savings</p>
+            <p className="mb-3 font-semibold md:mb-4 text-accent">Host Benefits</p>
             <h1 className="header-heading text-6xl font-bold md:text-7xl lg:text-8xl">
-              Charge Smartly Today
+              Share Your Charger, Earn Money
             </h1>
           </div>
           <div className="w-full max-w-lg">
             <p className="header-description md:text-md text-french-gray">
-              Discover the ease of charging your electric vehicle at home with
-              our innovative platform. Enjoy significant savings, enhanced
-              security, and unparalleled convenience by using a host's charger
-              instead of costly public options.
+              Turn your home EV charger into a source of income by sharing it with drivers in your area. 
+              Our platform makes it easy to list your charger, set your rates, and manage bookings.
             </p>
-            
-            {/* App Store Download Button */}
-            <div className="mt-6 mb-4">
-              <AppStoreButton 
-                href="https://apps.apple.com/your-app-store-link" 
-                className="inline-block"
-              />
-            </div>
-            
             <div className="header-buttons mt-6 flex justify-center flex-wrap gap-4 md:mt-8">
               <Button 
-                title="Learn More"
+                title="Become a Host"
                 className="bg-accent hover:bg-malachite text-governor-bay font-bold rounded-lg transition-all duration-300 hover:shadow-lg hover:-translate-y-1"
+                onClick={() => window.open("https://mailchi.mp/d3662d8474be/chargenextdoor", "_blank")}
+              >
+                Become a Host
+              </Button>
+            
+              <Button 
+                title="Learn More" 
+                variant="secondary"
                 onClick={() => window.location.href = "/contact-us"}
+                className="bg-transparent text-white font-bold border-2 border-accent rounded-lg transition-all duration-300 hover:bg-accent/10 hover:shadow-lg hover:-translate-y-1"
               >
                 Learn More
               </Button>
-              <Button 
-                title="Sign Up" 
-                variant="secondary"
-                className="bg-transparent text-white font-bold border-2 border-accent rounded-lg transition-all duration-300 hover:bg-accent/10 hover:shadow-lg hover:-translate-y-1"
-                onClick={() => window.open("https://mailchi.mp/d3662d8474be/chargenextdoor", "_blank")}
-              >
-                Sign Up
-              </Button>
+               
             </div>
           </div>
         </div>
       </div>
     </section>
   );
-}
+} 

--- a/src/cnd-app/for-hosts/components/WaitlistCTA.jsx
+++ b/src/cnd-app/for-hosts/components/WaitlistCTA.jsx
@@ -3,7 +3,7 @@
 import { Button } from "@relume_io/relume-ui";
 import React from "react";
 
-export function Cta19() {
+export function WaitlistCTA() {
   return (
     <section id="relume" className="relative px-[5%] py-16 md:py-24 lg:py-28">
       <div className="container flex flex-col items-center justify-center text-center">

--- a/src/cnd-app/for-hosts/index.jsx
+++ b/src/cnd-app/for-hosts/index.jsx
@@ -1,25 +1,25 @@
 "use client";
 
 import React from "react";
-import { Navbar12 } from "../../components/common/Navbar12";
-import { Header47 } from "./components/Header47";
+import { MainNavbar } from "../../components/common/MainNavbar";
+import { HostHeroHeader } from "./components/HostHeroHeader";
 import { Layout6 } from "./components/Layout6";
 import { Layout242 } from "./components/Layout242";
 import { Layout27 } from "./components/Layout27";
 import { Testimonial6 } from "./components/Testimonial6";
-import { Cta19 } from "./components/Cta19";
+import { WaitlistCTA } from "./components/WaitlistCTA";
 import { Footer2 } from "../../components/common/Footer2";
 
 export default function ForHosts() {
   return (
     <div className="min-h-screen bg-white">
-      <Navbar12 />
-      <Header47 />
+      <MainNavbar />
+      <HostHeroHeader />
       <Layout6 />
       <Layout242 />
       <Layout27 />
       <Testimonial6 />
-      <Cta19 />
+      <WaitlistCTA />
       <Footer2 />
     </div>
   );

--- a/src/cnd-app/home/components/CallToActionHero.jsx
+++ b/src/cnd-app/home/components/CallToActionHero.jsx
@@ -4,7 +4,7 @@ import React, { useEffect } from "react";
 import AppStoreButton from "../../../assets/Buttons/AppStoreButton";
 import PlayStoreButton from "../../../assets/Buttons/PlayStoreButton";
 
-export function Cta7() {
+export function CallToActionHero() {
   useEffect(() => {
     // Add intersection observer for scroll animations
     const observer = new IntersectionObserver((entries) => {

--- a/src/cnd-app/home/index.jsx
+++ b/src/cnd-app/home/index.jsx
@@ -1,18 +1,18 @@
 "use client";
 
 import React from "react";
-import { Navbar12 } from "../../components/common/Navbar12";
+import { MainNavbar } from "../../components/common/MainNavbar";
 import { Header1 } from "./components/Header1";
 import { Section2 } from "./components/section2";
 import { Testimonial14 } from "./components/Testimonial14";
-import { Cta7 } from "./components/Cta7";
+import { CallToActionHero } from "./components/CallToActionHero";
 import { Cta20 } from "./components/Cta20";
 import { Footer2 } from "../../components/common/Footer2";
 
 export default function Home() {
   return (
     <div className="min-h-screen bg-white">
-      <Navbar12 />
+      <MainNavbar />
       <br/>
       <Header1 />
       {/* <Layout12 /> */}
@@ -21,7 +21,7 @@ export default function Home() {
       {/* <Layout26 /> */}
       <Testimonial14 />
       {/* <Layout239 /> */}
-      <Cta7 />
+      <CallToActionHero />
       <Cta20 />
       <Footer2 />
     </div>

--- a/src/components/common/MainNavbar.jsx
+++ b/src/components/common/MainNavbar.jsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from "react";
 import logo from "../../assets/CND_Logo.png";
 
-export function Navbar12() {
+export function MainNavbar() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
 


### PR DESCRIPTION
## Summary
- rename navbar to MainNavbar
- rename home CTA to CallToActionHero
- rename driver header to SmartChargingHeader
- rename host components to HostHeroHeader and WaitlistCTA
- standardize contact FAQ as FaqSection

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden for postcss)*

------
https://chatgpt.com/codex/tasks/task_e_68c576e54ab08330972adbb2680a30c1