### PR TITLE
refactor: clean up spacing in cnd-app pages

### DIFF
--- a/src/cnd-app/about-us/index.jsx
+++ b/src/cnd-app/about-us/index.jsx
@@ -3,8 +3,6 @@
 import React from "react";
 import { MainNavbar } from "../../components/common/MainNavbar";
 import { Header47 } from "./components/Header47";
-import { Layout41 } from "./components/Layout41";
-import { Layout369 } from "./components/Layout369";
 import { Team8 } from "./components/Team8";
 import { Gallery8 } from "./components/Gallery8";
 import { Cta3 } from "./components/Cta3";
@@ -14,14 +12,13 @@ export default function AboutUs() {
   return (
     <div className="min-h-screen bg-white">
       <MainNavbar />
-      <br />
-      <Header47 />
-      {/* <Layout41 /> */}
-      {/* <Layout369 /> */}
-      <Team8 />
-      <Cta3 />
-      <Gallery8 />
-      <Footer2 />
+      <div className="mt-8 space-y-8">
+        <Header47 />
+        <Team8 />
+        <Cta3 />
+        <Gallery8 />
+        <Footer2 />
+      </div>
     </div>
   );
 }

--- a/src/cnd-app/contact-us/index.jsx
+++ b/src/cnd-app/contact-us/index.jsx
@@ -2,10 +2,7 @@
 
 import React from "react";
 import { MainNavbar } from "../../components/common/MainNavbar";
-import { Header47 } from "./components/Header47";
 import { Contact13 } from "./components/Contact13";
-import { Contact2 } from "./components/Contact2";
-import { Contact14 } from "./components/Contact14";
 import { FaqSection } from "./components/FaqSection";
 import { Footer2 } from "../../components/common/Footer2";
 
@@ -13,13 +10,12 @@ export default function ContactUs() {
   return (
     <div className="min-h-screen bg-white">
       <MainNavbar />
-      <br />
-      <br />
-      {/* <Header47 /> */}
-      {/* <Contact2 /> */}
-      {/* <Contact14 /> */}
-      <FaqSection />
-      <Contact13 />
+      <div className="mt-8">
+        <FaqSection />
+      </div>
+      <div className="mt-8">
+        <Contact13 />
+      </div>
       <Footer2 />
     </div>
   );

--- a/src/cnd-app/home/index.jsx
+++ b/src/cnd-app/home/index.jsx
@@ -13,14 +13,11 @@ export default function Home() {
   return (
     <div className="min-h-screen bg-white">
       <MainNavbar />
-      <br/>
-      <Header1 />
-      {/* <Layout12 /> */}
+      <div className="mt-8">
+        <Header1 />
+      </div>
       <Section2 />
-      {/* <Layout246 /> */}
-      {/* <Layout26 /> */}
       <Testimonial14 />
-      {/* <Layout239 /> */}
       <CallToActionHero />
       <Cta20 />
       <Footer2 />


### PR DESCRIPTION
## Summary
- drop commented components and `<br />` spacing in About Us, Contact Us, and Home pages
- add Tailwind margin wrappers for consistent spacing

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c5797442e08330a75438e824ea4c1c