### PR TITLE
refactor: use require for relume Tailwind

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 
-import relumeTailwind from "@relume_io/relume-tailwind";
+const relumeTailwind = require('@relume_io/relume-tailwind');
 
 module.exports = {
   content: [


### PR DESCRIPTION
## Summary
- use CommonJS require for `@relume_io/relume-tailwind` in Tailwind config

## Testing
- `npx tailwindcss -i ./src/index.css -o /tmp/tailwind-output.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tailwindcss)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c57d78ec688330993fc4d22647a8e6