### PR TITLE
chore: remove obsolete 'use client' directives

### DIFF
--- a/src/cnd-app/about-us/components/Cta3.jsx
+++ b/src/cnd-app/about-us/components/Cta3.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import MyImage from '../../../assets/ev-plugged-in.png';
 

--- a/src/cnd-app/about-us/components/Gallery8.jsx
+++ b/src/cnd-app/about-us/components/Gallery8.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import MyImage2 from '../../../assets/person-using-smartphone-to-book-a-charger-in-car.jpeg';
 import MyImage3 from '../../../assets/brainstorming.png';

--- a/src/cnd-app/about-us/components/Header47.jsx
+++ b/src/cnd-app/about-us/components/Header47.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { FaBolt, FaUsers, FaLeaf } from "react-icons/fa";
 import MyImage from '../../../assets/person-charging-ev-2.jpg';

--- a/src/cnd-app/about-us/components/Header64.jsx
+++ b/src/cnd-app/about-us/components/Header64.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 
 export function Header64() {

--- a/src/cnd-app/about-us/components/Layout369.jsx
+++ b/src/cnd-app/about-us/components/Layout369.jsx
@@ -1,5 +1,3 @@
-// "use client";
-
 // import { Button, Card } from "@relume_io/relume-ui";
 // import React from "react";
 // import { RxChevronRight } from "react-icons/rx";
@@ -112,7 +110,6 @@
 //   );
 // }
 
-// "use client";
 
 // import { Button, Carousel, CarouselContent, CarouselItem } from "@relume_io/relume-ui";
 // import React from "react";
@@ -228,7 +225,6 @@
 //   );
 // }
 
-// "use client";
 
 // import { Button, Sheet } from "@relume_io/relume-ui";
 // import React from "react";
@@ -342,7 +338,6 @@
 //   );
 // }
 
-"use client";
 
 import React from "react";
 import { FaBolt, FaHandshake, FaHome } from "react-icons/fa";

--- a/src/cnd-app/about-us/components/Layout41.jsx
+++ b/src/cnd-app/about-us/components/Layout41.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button } from "@relume_io/relume-ui";
 import React from "react";
 import { RxChevronRight } from "react-icons/rx";

--- a/src/cnd-app/about-us/components/Team4.jsx
+++ b/src/cnd-app/about-us/components/Team4.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { FaLinkedin, FaTwitter, FaGithub } from "react-icons/fa";
 

--- a/src/cnd-app/about-us/components/Team8.jsx
+++ b/src/cnd-app/about-us/components/Team8.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { BiLogoLinkedinSquare } from "react-icons/bi";
 import STimage from '../../../assets/st.jpg';

--- a/src/cnd-app/about-us/index.jsx
+++ b/src/cnd-app/about-us/index.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { MainNavbar } from "../../components/common/MainNavbar";
 import { Header47 } from "./components/Header47";

--- a/src/cnd-app/contact-us/components/Contact13.jsx
+++ b/src/cnd-app/contact-us/components/Contact13.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button } from "@relume_io/relume-ui";
 import React from "react";
 import { FaEnvelope } from "react-icons/fa";

--- a/src/cnd-app/contact-us/components/Contact14.jsx
+++ b/src/cnd-app/contact-us/components/Contact14.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button } from "@relume_io/relume-ui";
 import React from "react";
 import { BiEnvelope, BiMap, BiPhone } from "react-icons/bi";

--- a/src/cnd-app/contact-us/components/Contact2.jsx
+++ b/src/cnd-app/contact-us/components/Contact2.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   Button,
   Checkbox,

--- a/src/cnd-app/contact-us/components/Header47.jsx
+++ b/src/cnd-app/contact-us/components/Header47.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { useState } from "react";
 import { FaEnvelope, FaCheckCircle } from "react-icons/fa";
 import emailjs from 'emailjs-com';

--- a/src/cnd-app/contact-us/index.jsx
+++ b/src/cnd-app/contact-us/index.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { MainNavbar } from "../../components/common/MainNavbar";
 import { Contact13 } from "./components/Contact13";

--- a/src/cnd-app/for-drivers/components/Cta1.jsx
+++ b/src/cnd-app/for-drivers/components/Cta1.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button } from "@relume_io/relume-ui";
 import React from "react";
 

--- a/src/cnd-app/for-drivers/components/Layout12.jsx
+++ b/src/cnd-app/for-drivers/components/Layout12.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import HowItWorks from "./HowItWorks";
 import { Button } from "@relume_io/relume-ui";

--- a/src/cnd-app/for-drivers/components/Layout3.jsx
+++ b/src/cnd-app/for-drivers/components/Layout3.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { FaBolt, FaMoneyBillWave, FaMapMarkedAlt, FaShieldAlt, FaLeaf, FaUserFriends } from "react-icons/fa";
 

--- a/src/cnd-app/for-drivers/components/Layout3_1.jsx
+++ b/src/cnd-app/for-drivers/components/Layout3_1.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import MyImage from '../../../assets/car-coming-in.png';
 

--- a/src/cnd-app/for-drivers/components/SmartChargingHeader.jsx
+++ b/src/cnd-app/for-drivers/components/SmartChargingHeader.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button } from "@relume_io/relume-ui";
 import React, { useEffect } from "react";
 import AppStoreButton from "../../../assets/Buttons/AppStoreButton";

--- a/src/cnd-app/for-drivers/index.jsx
+++ b/src/cnd-app/for-drivers/index.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { MainNavbar } from "../../components/common/MainNavbar";
 import { SmartChargingHeader } from "./components/SmartChargingHeader";

--- a/src/cnd-app/for-hosts/components/Feature4.jsx
+++ b/src/cnd-app/for-hosts/components/Feature4.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { FaShieldAlt, FaMoneyBillWave, FaCalendarAlt } from "react-icons/fa";
 

--- a/src/cnd-app/for-hosts/components/Header46.jsx
+++ b/src/cnd-app/for-hosts/components/Header46.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 
 export function Header46() {

--- a/src/cnd-app/for-hosts/components/HostHeroHeader.jsx
+++ b/src/cnd-app/for-hosts/components/HostHeroHeader.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button } from "@relume_io/relume-ui";
 import React, { useEffect } from "react";
 

--- a/src/cnd-app/for-hosts/components/Layout242.jsx
+++ b/src/cnd-app/for-hosts/components/Layout242.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button } from "@relume_io/relume-ui";
 import React from "react";
 import { RxChevronRight } from "react-icons/rx";

--- a/src/cnd-app/for-hosts/components/Layout27.jsx
+++ b/src/cnd-app/for-hosts/components/Layout27.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import MyImage from '../../../assets/rating.png';
 import HowItWorks from './HowItWorks';

--- a/src/cnd-app/for-hosts/components/Layout6.jsx
+++ b/src/cnd-app/for-hosts/components/Layout6.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { FaMoneyBillWave, FaCalendarAlt, FaMobileAlt, FaChartLine, FaHandshake } from "react-icons/fa";
 import MyImage from '../../../assets/earning-figures-for-host.png';

--- a/src/cnd-app/for-hosts/components/Testimonial6.jsx
+++ b/src/cnd-app/for-hosts/components/Testimonial6.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { BiSolidStar } from "react-icons/bi";
 

--- a/src/cnd-app/for-hosts/components/WaitlistCTA.jsx
+++ b/src/cnd-app/for-hosts/components/WaitlistCTA.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button } from "@relume_io/relume-ui";
 import React from "react";
 

--- a/src/cnd-app/for-hosts/index.jsx
+++ b/src/cnd-app/for-hosts/index.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { MainNavbar } from "../../components/common/MainNavbar";
 import { HostHeroHeader } from "./components/HostHeroHeader";

--- a/src/cnd-app/home/components/CallToActionHero.jsx
+++ b/src/cnd-app/home/components/CallToActionHero.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { useEffect } from "react";
 import AppStoreButton from "../../../assets/Buttons/AppStoreButton";
 import PlayStoreButton from "../../../assets/Buttons/PlayStoreButton";

--- a/src/cnd-app/home/components/Cta20.jsx
+++ b/src/cnd-app/home/components/Cta20.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button, Input } from "@relume_io/relume-ui";
 import React from "react";
 import { FaBolt, FaEnvelope } from "react-icons/fa";

--- a/src/cnd-app/home/components/Header1.jsx
+++ b/src/cnd-app/home/components/Header1.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 // import Button removed: unused
 import React, { useEffect } from "react";
 import MyImage from "../../../assets/about-us-page.png";

--- a/src/cnd-app/home/components/Layout12.jsx
+++ b/src/cnd-app/home/components/Layout12.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { FaHome, FaCar, FaBolt } from "react-icons/fa";
 import MyImage from '../../../assets/host-and-driver.png';

--- a/src/cnd-app/home/components/Layout239.jsx
+++ b/src/cnd-app/home/components/Layout239.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import MyImage from '../../../assets/person-using-smartphone-to-locate-chargers.jpg';
 import MyImage2 from '../../../assets/person-using-smartphone-to-book-a-charger-in-car.jpeg';

--- a/src/cnd-app/home/components/Layout246.jsx
+++ b/src/cnd-app/home/components/Layout246.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button } from "@relume_io/relume-ui";
 import React from "react";
 import { RxChevronRight } from "react-icons/rx";

--- a/src/cnd-app/home/components/Layout26.jsx
+++ b/src/cnd-app/home/components/Layout26.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   Button,
 } from "@relume_io/relume-ui";

--- a/src/cnd-app/home/components/Testimonial14.jsx
+++ b/src/cnd-app/home/components/Testimonial14.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { BiSolidStar } from "react-icons/bi";
 import { FaQuoteLeft } from "react-icons/fa6";

--- a/src/cnd-app/home/components/section2.jsx
+++ b/src/cnd-app/home/components/section2.jsx
@@ -1,7 +1,3 @@
-
-
-"use client";
-
 import React from "react";
 import { FaHome, FaCar, FaBolt } from "react-icons/fa";
 import AutoPlayVideo from './autoplay';

--- a/src/cnd-app/home/index.jsx
+++ b/src/cnd-app/home/index.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { MainNavbar } from "../../components/common/MainNavbar";
 import { Header1 } from "./components/Header1";


### PR DESCRIPTION
## Summary
- remove `use client` directives from cnd-app components

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 forbidden for postcss package)*

------
https://chatgpt.com/codex/tasks/task_e_68c58f2d7c48833083565cd996ff07d2