### PR TITLE
refactor: replace gradients with muted surfaces

### DIFF
--- a/src/cnd-app/about-us/components/Cta3.jsx
+++ b/src/cnd-app/about-us/components/Cta3.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Button } from "../../../components/ui/button";
 import MyImage from '../../../assets/ev-plugged-in.png';
 
 export function Cta3() {
@@ -11,54 +12,55 @@ export function Cta3() {
           className="size-full object-cover"
           alt="EV plugged in charging"
         />
-        <div className="absolute inset-0 bg-gradient-to-br from-black/60 via-black/40 to-black/60" />
+        <div className="absolute inset-0 bg-black/60" />
       </div>
 
       {/* Background decorative elements */}
-      <div className="absolute -top-20 -right-20 w-64 h-64 bg-gradient-to-r from-emerald-400/10 to-blue-400/10 rounded-full blur-3xl z-10"></div>
-      <div className="absolute bottom-10 -left-20 w-80 h-80 bg-gradient-to-r from-blue-400/10 to-purple-400/10 rounded-full blur-3xl z-10"></div>
+      <div className="absolute -top-20 -right-20 w-64 h-64 bg-muted rounded-full blur-3xl z-10"></div>
+      <div className="absolute bottom-10 -left-20 w-80 h-80 bg-muted rounded-full blur-3xl z-10"></div>
 
       {/* Content */}
       <div className="relative z-20 flex justify-center">
         <div className="w-full max-w-4xl text-center">
           {/* Badge */}
-          <div className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-emerald-50/90 to-blue-50/90 border border-emerald-200/50 rounded-full text-sm font-medium text-emerald-700 shadow-sm backdrop-blur-md mb-6">
+          <div className="inline-flex items-center px-4 py-2 bg-muted border rounded-full text-sm font-medium text-foreground shadow-sm mb-6">
             <span className="w-2 h-2 bg-emerald-400 rounded-full mr-2 animate-pulse"></span>
             Join the Revolution ⚡
           </div>
 
           {/* Heading */}
-          <h2 className="text-4xl leading-[1.2] font-bold md:text-5xl lg:text-6xl bg-gradient-to-r from-white via-emerald-100 to-blue-100 bg-clip-text text-transparent mb-6">
+          <h2 className="text-4xl leading-[1.2] font-bold md:text-5xl lg:text-6xl text-foreground mb-6">
             Join the EV Charging Revolution
           </h2>
 
           {/* Description */}
-          <p className="text-lg text-white/90 leading-relaxed mb-8 max-w-2xl mx-auto">
-            Become a host or EV owner and help shape the future of electric vehicle charging. 
+          <p className="text-lg text-muted-foreground leading-relaxed mb-8 max-w-2xl mx-auto">
+            Become a host or EV owner and help shape the future of electric vehicle charging.
             Join our community and be part of the sustainable transportation revolution.
           </p>
 
           {/* Buttons */}
           <div className="flex flex-wrap items-center justify-center gap-6">
-            <button 
+            <Button
               onClick={() => window.open("https://mailchi.mp/d3662d8474be/chargenextdoor", "_blank")}
-              className="inline-flex items-center gap-2 bg-gradient-to-r from-emerald-500/90 to-blue-500/90 backdrop-blur-md border border-emerald-300/50 hover:border-emerald-400/70 hover:from-emerald-500 hover:to-blue-500 text-white font-bold rounded-xl transition-all duration-300 hover:shadow-xl hover:-translate-y-2 hover:scale-105 px-8 py-4 text-lg shadow-lg group"
+              className="group px-8 py-4 text-lg font-bold shadow-lg transition-all duration-300 hover:shadow-xl hover:-translate-y-2 hover:scale-105"
             >
               Join the Waitlist for Android
-              <svg className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4 ml-2 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
               </svg>
-            </button>
+            </Button>
 
-            <a 
-              href="/contact-us"
-              className="inline-flex items-center gap-2 text-white hover:text-emerald-200 text-lg bg-gradient-to-r from-white/10 to-emerald-50/20 backdrop-blur-md border border-white/30 hover:border-emerald-300/50 rounded-xl px-6 py-3 hover:bg-gradient-to-r hover:from-white/20 hover:to-emerald-50/30 transition-all duration-300 hover:shadow-lg hover:-translate-y-1 font-semibold group"
+            <Button
+              variant="ghost"
+              onClick={() => (window.location.href = "/contact-us")}
+              className="group px-6 py-3 text-lg font-semibold"
             >
               Learn More
-              <svg className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4 ml-2 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
               </svg>
-            </a>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/cnd-app/about-us/components/Gallery8.jsx
+++ b/src/cnd-app/about-us/components/Gallery8.jsx
@@ -7,22 +7,22 @@ import MyImage6 from '../../../assets/charging-community.webp';
 
 export function Gallery8() {
   return (
-    <section className="px-[5%] py-16 md:py-24 lg:py-28 relative overflow-hidden bg-gradient-to-br from-white to-slate-50">
+    <section className="px-[5%] py-16 md:py-24 lg:py-28 relative overflow-hidden bg-muted">
       {/* Background decorative elements */}
-      <div className="absolute -top-20 -left-20 w-64 h-64 bg-gradient-to-r from-emerald-400/5 to-blue-400/5 rounded-full blur-3xl"></div>
-      <div className="absolute bottom-10 -right-20 w-80 h-80 bg-gradient-to-r from-blue-400/5 to-purple-400/5 rounded-full blur-3xl"></div>
+      <div className="absolute -top-20 -left-20 w-64 h-64 bg-muted rounded-full blur-3xl"></div>
+      <div className="absolute bottom-10 -right-20 w-80 h-80 bg-muted rounded-full blur-3xl"></div>
       
       <div className="container relative z-10">
         {/* Header Section */}
         <div className="mb-12 text-center md:mb-18 lg:mb-20">
-          <div className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-emerald-50 to-blue-50 border border-emerald-200/50 rounded-full text-sm font-medium text-emerald-700 shadow-sm backdrop-blur-sm mb-6 mx-auto">
+          <div className="inline-flex items-center px-4 py-2 bg-muted border rounded-full text-sm font-medium text-foreground shadow-sm mb-6 mx-auto">
             <span className="w-2 h-2 bg-emerald-400 rounded-full mr-2 animate-pulse"></span>
             Our Journey 📸
           </div>
-          <h2 className="text-4xl leading-[1.2] font-bold md:text-5xl lg:text-6xl bg-gradient-to-r from-emerald-600 to-blue-600 bg-clip-text text-transparent mb-6">
+          <h2 className="text-4xl leading-[1.2] font-bold md:text-5xl lg:text-6xl text-foreground mb-6">
             Photo Showcase
           </h2>
-          <p className="text-lg text-gray-700 leading-relaxed max-w-2xl mx-auto">
+          <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl mx-auto">
             Explore our journey and community connections through images that tell the story of EV charging innovation.
           </p>
         </div>
@@ -30,57 +30,57 @@ export function Gallery8() {
         {/* Gallery Grid */}
         <div className="gap-x-8 md:columns-2">
           <div className="mb-8 inline-block w-full group">
-            <div className="relative inline-block w-full pt-[100%] rounded-2xl overflow-hidden bg-gradient-to-r from-white/80 to-emerald-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+            <div className="relative inline-block w-full pt-[100%] rounded-2xl overflow-hidden bg-muted backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
               <img
                 src={MyImage2}
                 alt="Person using smartphone to book charger"
                 className="absolute inset-2 size-[calc(100%-16px)] rounded-xl object-cover group-hover:scale-105 transition-transform duration-500"
               />
-              <div className="absolute inset-2 rounded-xl bg-gradient-to-t from-black/20 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+              <div className="absolute inset-2 rounded-xl bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
             </div>
           </div>
           
           <div className="mb-8 inline-block w-full group">
-            <div className="relative inline-block w-full pt-[66.66%] rounded-2xl overflow-hidden bg-gradient-to-r from-white/80 to-blue-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+            <div className="relative inline-block w-full pt-[66.66%] rounded-2xl overflow-hidden bg-muted backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
               <img
                 src={MyImage6}
                 alt="Charging community"
                 className="absolute inset-2 size-[calc(100%-16px)] rounded-xl object-cover group-hover:scale-105 transition-transform duration-500"
               />
-              <div className="absolute inset-2 rounded-xl bg-gradient-to-t from-black/20 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+              <div className="absolute inset-2 rounded-xl bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
             </div>
           </div>
 
           <div className="mb-8 inline-block w-full group">
-            <div className="relative inline-block w-full pt-[150%] rounded-2xl overflow-hidden bg-gradient-to-r from-white/80 to-purple-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+            <div className="relative inline-block w-full pt-[150%] rounded-2xl overflow-hidden bg-muted backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
               <img
                 src={MyImage5}
                 alt="EV charger in garage"
                 className="absolute inset-2 size-[calc(100%-16px)] rounded-xl object-cover group-hover:scale-105 transition-transform duration-500"
               />
-              <div className="absolute inset-2 rounded-xl bg-gradient-to-t from-black/20 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+              <div className="absolute inset-2 rounded-xl bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
             </div>
           </div>
 
           <div className="mb-8 inline-block w-full group">
-            <div className="relative inline-block w-full pt-[150%] rounded-2xl overflow-hidden bg-gradient-to-r from-white/80 to-teal-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+            <div className="relative inline-block w-full pt-[150%] rounded-2xl overflow-hidden bg-muted backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
               <img
                 src={MyImage4}
                 alt="Testing charger on site"
                 className="absolute inset-2 size-[calc(100%-16px)] rounded-xl object-cover group-hover:scale-105 transition-transform duration-500"
               />
-              <div className="absolute inset-2 rounded-xl bg-gradient-to-t from-black/20 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+              <div className="absolute inset-2 rounded-xl bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
             </div>
           </div>
 
           <div className="mb-8 inline-block w-full group">
-            <div className="relative inline-block w-full pt-[100%] rounded-2xl overflow-hidden bg-gradient-to-r from-white/80 to-orange-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+            <div className="relative inline-block w-full pt-[100%] rounded-2xl overflow-hidden bg-muted backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
               <img
                 src={MyImage3}
                 alt="Team brainstorming session"
                 className="absolute inset-2 size-[calc(100%-16px)] rounded-xl object-cover group-hover:scale-105 transition-transform duration-500"
               />
-              <div className="absolute inset-2 rounded-xl bg-gradient-to-t from-black/20 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+              <div className="absolute inset-2 rounded-xl bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
             </div>
           </div>
         </div>

--- a/src/cnd-app/about-us/components/Header47.jsx
+++ b/src/cnd-app/about-us/components/Header47.jsx
@@ -1,65 +1,72 @@
 import React from "react";
 import { FaBolt, FaUsers, FaLeaf } from "react-icons/fa";
+import { Card, CardContent } from "../../../components/ui/card";
 import MyImage from '../../../assets/person-charging-ev-2.jpg';
 
 export function Header47() {
   return (
-    <section className="px-[5%] py-16 md:py-24 lg:py-28 pt-32 relative overflow-hidden bg-gradient-to-br from-slate-50 to-blue-50">
+    <section className="px-[5%] py-16 md:py-24 lg:py-28 pt-32 relative overflow-hidden bg-muted">
       {/* Background decorative elements */}
-      <div className="absolute -top-20 -right-20 w-64 h-64 bg-gradient-to-r from-emerald-400/10 to-blue-400/10 rounded-full blur-3xl"></div>
-      <div className="absolute bottom-10 -left-20 w-80 h-80 bg-gradient-to-r from-blue-400/10 to-purple-400/10 rounded-full blur-3xl"></div>
+      <div className="absolute -top-20 -right-20 w-64 h-64 bg-muted rounded-full blur-3xl"></div>
+      <div className="absolute bottom-10 -left-20 w-80 h-80 bg-muted rounded-full blur-3xl"></div>
       
       <div className="container relative z-10">
         <div className="grid grid-cols-1 gap-y-12 md:grid-cols-2 md:items-center md:gap-x-12 lg:gap-x-20">
           
           {/* Text Content - LEFT SIDE */}
           <div className="space-y-6">
-            <div className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-emerald-50 to-blue-50 border border-emerald-200/50 rounded-full text-sm font-medium text-emerald-700 shadow-sm backdrop-blur-sm mb-6">
+            <div className="inline-flex items-center px-4 py-2 bg-muted border rounded-full text-sm font-medium text-foreground shadow-sm mb-6">
               <span className="w-2 h-2 bg-emerald-400 rounded-full mr-2 animate-pulse"></span>
               Our Story ⚡
             </div>
             
-            <h1 className="text-4xl leading-[1.2] font-bold md:text-5xl lg:text-6xl bg-gradient-to-r from-emerald-600 to-blue-600 bg-clip-text text-transparent">
+            <h1 className="text-4xl leading-[1.2] font-bold md:text-5xl lg:text-6xl text-foreground">
               Connecting EV Owners with Local Hosts
             </h1>
             
-            <p className="text-lg text-gray-700 leading-relaxed">
-              ChargeNextDoor was founded with a simple mission: to make EV charging more accessible, 
-              affordable, and community-driven. We believe in the power of sharing resources to 
+            <p className="text-lg text-muted-foreground leading-relaxed">
+              ChargeNextDoor was founded with a simple mission: to make EV charging more accessible,
+              affordable, and community-driven. We believe in the power of sharing resources to
               create a more sustainable future.
             </p>
 
             {/* Mission Cards */}
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 mt-8">
-              <div className="p-4 rounded-xl bg-gradient-to-r from-white/80 to-emerald-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1 group text-center">
-                <div className="mb-3 flex justify-center">
-                  <div className="size-10 rounded-full bg-gradient-to-r from-emerald-500/20 to-blue-500/20 backdrop-blur-sm flex items-center justify-center group-hover:from-emerald-500/30 group-hover:to-blue-500/30 transition-all duration-300">
-                    <FaBolt className="size-5 text-emerald-600" />
+              <Card className="text-center shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+                <CardContent className="p-4">
+                  <div className="mb-3 flex justify-center">
+                    <div className="size-10 rounded-full bg-emerald-500/20 flex items-center justify-center">
+                      <FaBolt className="size-5 text-emerald-600" />
+                    </div>
                   </div>
-                </div>
-                <h6 className="text-sm font-bold text-gray-800 mb-1">Innovation</h6>
-                <p className="text-xs text-gray-600">Leading EV charging solutions</p>
-              </div>
-              
-              <div className="p-4 rounded-xl bg-gradient-to-r from-white/80 to-blue-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1 group text-center">
-                <div className="mb-3 flex justify-center">
-                  <div className="size-10 rounded-full bg-gradient-to-r from-blue-500/20 to-purple-500/20 backdrop-blur-sm flex items-center justify-center group-hover:from-blue-500/30 group-hover:to-purple-500/30 transition-all duration-300">
-                    <FaUsers className="size-5 text-blue-600" />
-                  </div>
-                </div>
-                <h6 className="text-sm font-bold text-gray-800 mb-1">Community</h6>
-                <p className="text-xs text-gray-600">Connecting neighbors</p>
-              </div>
+                  <h6 className="text-sm font-bold text-foreground mb-1">Innovation</h6>
+                  <p className="text-xs text-muted-foreground">Leading EV charging solutions</p>
+                </CardContent>
+              </Card>
 
-              <div className="p-4 rounded-xl bg-gradient-to-r from-white/80 to-green-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1 group text-center">
-                <div className="mb-3 flex justify-center">
-                  <div className="size-10 rounded-full bg-gradient-to-r from-green-500/20 to-emerald-500/20 backdrop-blur-sm flex items-center justify-center group-hover:from-green-500/30 group-hover:to-emerald-500/30 transition-all duration-300">
-                    <FaLeaf className="size-5 text-green-600" />
+              <Card className="text-center shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+                <CardContent className="p-4">
+                  <div className="mb-3 flex justify-center">
+                    <div className="size-10 rounded-full bg-blue-500/20 flex items-center justify-center">
+                      <FaUsers className="size-5 text-blue-600" />
+                    </div>
                   </div>
-                </div>
-                <h6 className="text-sm font-bold text-gray-800 mb-1">Sustainability</h6>
-                <p className="text-xs text-gray-600">Green future together</p>
-              </div>
+                  <h6 className="text-sm font-bold text-foreground mb-1">Community</h6>
+                  <p className="text-xs text-muted-foreground">Connecting neighbors</p>
+                </CardContent>
+              </Card>
+
+              <Card className="text-center shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+                <CardContent className="p-4">
+                  <div className="mb-3 flex justify-center">
+                    <div className="size-10 rounded-full bg-green-500/20 flex items-center justify-center">
+                      <FaLeaf className="size-5 text-green-600" />
+                    </div>
+                  </div>
+                  <h6 className="text-sm font-bold text-foreground mb-1">Sustainability</h6>
+                  <p className="text-xs text-muted-foreground">Green future together</p>
+                </CardContent>
+              </Card>
             </div>
           </div>
 
@@ -73,10 +80,10 @@ export function Header47() {
               />
               
               {/* Floating glassmorphism elements */}
-              <div className="absolute -top-8 -left-8 w-16 h-16 bg-gradient-to-br from-emerald-400/15 to-blue-400/15 backdrop-blur-md rounded-2xl border border-white/20 flex items-center justify-center shadow-lg hover:from-emerald-400/25 hover:to-blue-400/25 hover:scale-105 transition-all duration-700 animate-pulse" style={{animationDuration: '3s'}}>
+              <div className="absolute -top-8 -left-8 w-16 h-16 bg-muted backdrop-blur-md rounded-2xl border border-white/20 flex items-center justify-center shadow-lg hover:scale-105 transition-all duration-700 animate-pulse" style={{animationDuration: '3s'}}>
                 <span className="text-2xl opacity-80">⚡</span>
               </div>
-              <div className="absolute -bottom-8 -right-8 w-14 h-14 bg-gradient-to-br from-blue-400/15 to-purple-400/15 backdrop-blur-md rounded-2xl border border-white/20 flex items-center justify-center shadow-lg hover:from-blue-400/25 hover:to-purple-400/25 hover:scale-105 transition-all duration-700 animate-pulse" style={{animationDuration: '4s'}}>
+              <div className="absolute -bottom-8 -right-8 w-14 h-14 bg-muted backdrop-blur-md rounded-2xl border border-white/20 flex items-center justify-center shadow-lg hover:scale-105 transition-all duration-700 animate-pulse" style={{animationDuration: '4s'}}>
                 <span className="text-xl opacity-80">🌱</span>
               </div>
             </div>

--- a/src/cnd-app/about-us/components/Layout369.jsx
+++ b/src/cnd-app/about-us/components/Layout369.jsx
@@ -342,29 +342,31 @@
 import React from "react";
 import { FaBolt, FaHandshake, FaHome } from "react-icons/fa";
 import { BiChevronRight } from "react-icons/bi";
+import { Card, CardContent } from "../../../components/ui/card";
+import { Button } from "../../../components/ui/button";
 import ChargingImage from '../../../assets/person-using-smartphone-to-book-a-charger-in-car.jpeg';
 import CommunityImage from '../../../assets/charging-community.webp';
 import HostImage from '../../../assets/ev-charger-in-garage.jpeg';
 
 export function Layout369() {
   return (
-    <section className="px-[5%] py-16 md:py-24 lg:py-28 relative overflow-hidden bg-gradient-to-br from-white to-slate-50">
+    <section className="px-[5%] py-16 md:py-24 lg:py-28 relative overflow-hidden bg-muted">
       {/* Background decorative elements */}
-      <div className="absolute -top-20 -left-20 w-64 h-64 bg-gradient-to-r from-emerald-400/5 to-blue-400/5 rounded-full blur-3xl"></div>
-      <div className="absolute bottom-10 -right-20 w-80 h-80 bg-gradient-to-r from-blue-400/5 to-purple-400/5 rounded-full blur-3xl"></div>
+      <div className="absolute -top-20 -left-20 w-64 h-64 bg-muted rounded-full blur-3xl"></div>
+      <div className="absolute bottom-10 -right-20 w-80 h-80 bg-muted rounded-full blur-3xl"></div>
       
       <div className="container relative z-10">
         {/* Header Section */}
         <div className="mb-12 md:mb-18 lg:mb-20">
           <div className="mx-auto max-w-3xl text-center">
-            <div className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-emerald-50 to-blue-50 border border-emerald-200/50 rounded-full text-sm font-medium text-emerald-700 shadow-sm backdrop-blur-sm mb-6">
+            <div className="inline-flex items-center px-4 py-2 bg-muted border rounded-full text-sm font-medium text-foreground shadow-sm mb-6">
               <span className="w-2 h-2 bg-emerald-400 rounded-full mr-2 animate-pulse"></span>
               Our Mission ⚡
             </div>
-            <h2 className="text-4xl leading-[1.2] font-bold md:text-5xl lg:text-6xl bg-gradient-to-r from-emerald-600 to-blue-600 bg-clip-text text-transparent mb-6">
+            <h2 className="text-4xl leading-[1.2] font-bold md:text-5xl lg:text-6xl text-foreground mb-6">
               Empowering EV Charging Access
             </h2>
-            <p className="text-lg text-gray-700 leading-relaxed">
+            <p className="text-lg text-muted-foreground leading-relaxed">
               Bridging the gap between hosts and EV owners through innovative community-driven solutions.
             </p>
           </div>
@@ -375,106 +377,106 @@ export function Layout369() {
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:gap-8 lg:grid-cols-4">
             
             {/* Large Featured Card */}
-            <div className="grid grid-cols-1 sm:col-span-2 sm:row-span-1 sm:grid-cols-2 rounded-2xl bg-gradient-to-r from-white/80 to-emerald-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1 overflow-hidden group">
-              <div className="flex flex-1 flex-col justify-center p-8">
+            <Card className="grid grid-cols-1 sm:col-span-2 sm:row-span-1 sm:grid-cols-2 overflow-hidden">
+              <CardContent className="flex flex-1 flex-col justify-center p-8">
                 <div className="mb-4">
-                  <div className="size-12 rounded-full bg-gradient-to-r from-emerald-500/20 to-blue-500/20 backdrop-blur-sm flex items-center justify-center group-hover:from-emerald-500/30 group-hover:to-blue-500/30 transition-all duration-300 mb-4">
+                  <div className="size-12 rounded-full bg-emerald-500/20 flex items-center justify-center mb-4">
                     <FaBolt className="size-6 text-emerald-600" />
                   </div>
                 </div>
                 <div>
-                  <div className="inline-flex items-center px-3 py-1 bg-emerald-100/60 border border-emerald-200/50 rounded-full text-xs font-medium text-emerald-700 mb-3">
+                  <div className="inline-flex items-center px-3 py-1 bg-muted border rounded-full text-xs font-medium text-foreground mb-3">
                     Connect
                   </div>
-                  <h3 className="text-xl font-bold text-gray-800 mb-3 md:text-2xl">
+                  <h3 className="text-xl font-bold text-foreground mb-3 md:text-2xl">
                     Seamless Charging Solutions for Everyone
                   </h3>
-                  <p className="text-gray-600 mb-4">
+                  <p className="text-muted-foreground mb-4">
                     Find reliable chargers near you with our innovative platform that connects communities.
                   </p>
                 </div>
-                <div className="flex items-center gap-2 text-emerald-600 font-semibold group-hover:gap-3 transition-all duration-300">
-                  <span className="text-sm">Learn More</span>
-                  <BiChevronRight className="size-5 group-hover:translate-x-1 transition-transform duration-300" />
-                </div>
-              </div>
+                <Button variant="ghost" className="group w-fit gap-2 text-emerald-600">
+                  Learn More
+                  <BiChevronRight className="size-5 transition-transform group-hover:translate-x-1" />
+                </Button>
+              </CardContent>
               <div className="relative overflow-hidden">
                 <img
                   src={ChargingImage}
                   alt="Person using smartphone to book charger"
                   className="size-full object-cover group-hover:scale-105 transition-transform duration-500"
                 />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent"></div>
+                <div className="absolute inset-0 bg-black/20"></div>
               </div>
-            </div>
+            </Card>
 
             {/* Small Card 1 - Community */}
-            <div className="flex flex-col rounded-2xl bg-gradient-to-r from-white/80 to-blue-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1 overflow-hidden group">
-              <div className="flex flex-col justify-center p-6">
+            <Card className="flex flex-col overflow-hidden group shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+              <CardContent className="flex flex-col justify-center p-6">
                 <div className="mb-4">
-                  <div className="size-10 rounded-full bg-gradient-to-r from-blue-500/20 to-purple-500/20 backdrop-blur-sm flex items-center justify-center group-hover:from-blue-500/30 group-hover:to-purple-500/30 transition-all duration-300">
+                  <div className="size-10 rounded-full bg-blue-500/20 flex items-center justify-center">
                     <FaHandshake className="size-5 text-blue-600" />
                   </div>
                 </div>
                 <div>
-                  <div className="inline-flex items-center px-3 py-1 bg-blue-100/60 border border-blue-200/50 rounded-full text-xs font-medium text-blue-700 mb-3">
+                  <div className="inline-flex items-center px-3 py-1 bg-muted border rounded-full text-xs font-medium text-foreground mb-3">
                     Community
                   </div>
-                  <h3 className="text-lg font-bold text-gray-800 mb-2">
+                  <h3 className="text-lg font-bold text-foreground mb-2">
                     Join Our Network
                   </h3>
-                  <p className="text-sm text-gray-600 mb-4">
+                  <p className="text-sm text-muted-foreground mb-4">
                     Connect with hosts and charge effortlessly in your neighborhood.
                   </p>
                 </div>
-                <div className="flex items-center gap-2 text-blue-600 font-semibold text-sm group-hover:gap-3 transition-all duration-300">
-                  <span>Sign Up</span>
-                  <BiChevronRight className="size-4 group-hover:translate-x-1 transition-transform duration-300" />
-                </div>
-              </div>
+                <Button variant="ghost" className="group w-fit gap-2 text-blue-600 text-sm">
+                  Sign Up
+                  <BiChevronRight className="size-4 transition-transform group-hover:translate-x-1" />
+                </Button>
+              </CardContent>
               <div className="relative overflow-hidden">
-                <img 
-                  src={CommunityImage} 
-                  alt="Charging community" 
-                  className="w-full h-32 object-cover group-hover:scale-105 transition-transform duration-500" 
+                <img
+                  src={CommunityImage}
+                  alt="Charging community"
+                  className="w-full h-32 object-cover group-hover:scale-105 transition-transform duration-500"
                 />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent"></div>
+                <div className="absolute inset-0 bg-black/20"></div>
               </div>
-            </div>
+            </Card>
 
             {/* Small Card 2 - For Hosts */}
-            <div className="flex flex-col rounded-2xl bg-gradient-to-r from-white/80 to-purple-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1 overflow-hidden group">
-              <div className="flex flex-col justify-center p-6">
+            <Card className="flex flex-col overflow-hidden group shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
+              <CardContent className="flex flex-col justify-center p-6">
                 <div className="mb-4">
-                  <div className="size-10 rounded-full bg-gradient-to-r from-purple-500/20 to-pink-500/20 backdrop-blur-sm flex items-center justify-center group-hover:from-purple-500/30 group-hover:to-pink-500/30 transition-all duration-300">
+                  <div className="size-10 rounded-full bg-purple-500/20 flex items-center justify-center">
                     <FaHome className="size-5 text-purple-600" />
                   </div>
                 </div>
                 <div>
-                  <div className="inline-flex items-center px-3 py-1 bg-purple-100/60 border border-purple-200/50 rounded-full text-xs font-medium text-purple-700 mb-3">
+                  <div className="inline-flex items-center px-3 py-1 bg-muted border rounded-full text-xs font-medium text-foreground mb-3">
                     Earn Income
                   </div>
-                  <h3 className="text-lg font-bold text-gray-800 mb-2">
+                  <h3 className="text-lg font-bold text-foreground mb-2">
                     Become a Host
                   </h3>
-                  <p className="text-sm text-gray-600 mb-4">
+                  <p className="text-sm text-muted-foreground mb-4">
                     Share your charger and earn extra income while helping your community.
                   </p>
                 </div>
-                <div className="flex items-center gap-2 text-purple-600 font-semibold text-sm group-hover:gap-3 transition-all duration-300">
-                  <span>Get Started</span>
-                  <BiChevronRight className="size-4 group-hover:translate-x-1 transition-transform duration-300" />
-                </div>
-              </div>
+                <Button variant="ghost" className="group w-fit gap-2 text-purple-600 text-sm">
+                  Get Started
+                  <BiChevronRight className="size-4 transition-transform group-hover:translate-x-1" />
+                </Button>
+              </CardContent>
               <div className="relative overflow-hidden">
-                <img 
-                  src={HostImage} 
-                  alt="EV charger in garage" 
-                  className="w-full h-32 object-cover group-hover:scale-105 transition-transform duration-500" 
+                <img
+                  src={HostImage}
+                  alt="EV charger in garage"
+                  className="w-full h-32 object-cover group-hover:scale-105 transition-transform duration-500"
                 />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent"></div>
+                <div className="absolute inset-0 bg-black/20"></div>
               </div>
-            </div>
+            </Card>
           </div>
         </div>
       </div>

--- a/src/cnd-app/about-us/components/Layout41.jsx
+++ b/src/cnd-app/about-us/components/Layout41.jsx
@@ -1,6 +1,6 @@
-import { Button } from "@relume_io/relume-ui";
 import React from "react";
 import { RxChevronRight } from "react-icons/rx";
+import { Button } from "../../../components/ui/button";
 
 export function Layout41() {
   return (
@@ -8,35 +8,33 @@ export function Layout41() {
       <div className="container">
         <div className="grid grid-cols-1 gap-5 md:grid-cols-2 md:gap-x-12 md:gap-y-8 lg:gap-x-20">
           <div>
-            <p className="mb-3 font-semibold md:mb-4 text-governor-bay">Connect</p>
-            <h2 className="text-5xl font-bold md:text-7xl lg:text-8xl text-governor-bay">
+            <p className="mb-3 font-semibold md:mb-4 text-muted-foreground">Connect</p>
+            <h2 className="text-5xl font-bold md:text-7xl lg:text-8xl text-foreground">
               Empowering Electric Vehicle Charging for Everyone
             </h2>
           </div>
           <div>
-            <p className="md:text-md">
+            <p className="md:text-md text-muted-foreground">
               Founded on the belief that charging should be accessible to all,
               we connect EV owners with hosts offering home chargers. Our
               mission is to create a sustainable future by making electric
               vehicle charging simple and convenient.
             </p>
             <div className="mt-6 flex flex-wrap items-center gap-4 md:mt-8">
-              <a
-                href="/contact-us" // or any path you want to link to
-                className="bg-governor-bay hover:bg-malachite text-white font-bold rounded-lg transition-all duration-300 hover:shadow-lg hover:-translate-y-1 px-8 py-3 text-lg "
+              <Button
+                onClick={() => (window.location.href = "/contact-us")}
+                className="text-lg"
               >
                 Learn More
-              </a>
-                <Button
-                    title="Sign Up"
-                    variant="link"
-                    size="link"
-                    iconRight={<RxChevronRight />}
-                    className="text-governor-bay hover:text-malachite text-lg"
-                    onClick={() => window.open("https://mailchi.mp/d3662d8474be/chargenextdoor", "_blank")}
-                    >
-                    Sign Up
-                  </Button>
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => window.open("https://mailchi.mp/d3662d8474be/chargenextdoor", "_blank")}
+                className="text-lg gap-1"
+              >
+                Sign Up
+                <RxChevronRight className="size-4" />
+              </Button>
             </div>
           </div>
         </div>

--- a/src/cnd-app/about-us/components/Team4.jsx
+++ b/src/cnd-app/about-us/components/Team4.jsx
@@ -10,7 +10,7 @@ export function Team4() {
             <h2 className="mb-5 text-5xl font-bold md:mb-6 md:text-7xl lg:text-8xl ">
               Meet Our Team
             </h2>
-            <p className="md:text-md text-french-gray">
+            <p className="md:text-md text-muted-foreground">
               The passionate individuals behind ChargeNextDoor who are dedicated to revolutionizing EV charging.
             </p>
           </div>
@@ -25,17 +25,17 @@ export function Team4() {
               />
             </div>
             <h3 className="mb-1 text-xl font-bold md:text-2xl">Kyle Smith</h3>
-            <p className="mb-4 text-french-gray">CEO & Co-Founder</p>
+            <p className="mb-4 text-muted-foreground">CEO & Co-Founder</p>
             <div className="flex gap-4">
               <a
                 href="#"
-                className="flex size-10 items-center justify-center rounded-full bg-governor-bay/10 text-governor-bay hover:bg-governor-bay hover:text-white transition-colors duration-300"
+                className="flex size-10 items-center justify-center rounded-full bg-muted text-foreground hover:bg-muted/80 transition-colors duration-300"
               >
                 <FaLinkedin />
               </a>
               <a
                 href="#"
-                className="flex size-10 items-center justify-center rounded-full bg-governor-bay/10 text-governor-bay hover:bg-governor-bay hover:text-white transition-colors duration-300"
+                className="flex size-10 items-center justify-center rounded-full bg-muted text-foreground hover:bg-muted/80 transition-colors duration-300"
               >
                 <FaTwitter />
               </a>
@@ -50,17 +50,17 @@ export function Team4() {
               />
             </div>
             <h3 className="mb-1 text-xl font-bold md:text-2xl">Sarah Johnson</h3>
-            <p className="mb-4 text-french-gray">CTO & Co-Founder</p>
+            <p className="mb-4 text-muted-foreground">CTO & Co-Founder</p>
             <div className="flex gap-4">
               <a
                 href="#"
-                className="flex size-10 items-center justify-center rounded-full bg-governor-bay/10 text-governor-bay hover:bg-governor-bay hover:text-white transition-colors duration-300"
+                className="flex size-10 items-center justify-center rounded-full bg-muted text-foreground hover:bg-muted/80 transition-colors duration-300"
               >
                 <FaLinkedin />
               </a>
               <a
                 href="#"
-                className="flex size-10 items-center justify-center rounded-full bg-governor-bay/10 text-governor-bay hover:bg-governor-bay hover:text-white transition-colors duration-300"
+                className="flex size-10 items-center justify-center rounded-full bg-muted text-foreground hover:bg-muted/80 transition-colors duration-300"
               >
                 <FaGithub />
               </a>
@@ -75,17 +75,17 @@ export function Team4() {
               />
             </div>
             <h3 className="mb-1 text-xl font-bold md:text-2xl">David Chen</h3>
-            <p className="mb-4 text-french-gray">Head of Product</p>
+            <p className="mb-4 text-muted-foreground">Head of Product</p>
             <div className="flex gap-4">
               <a
                 href="#"
-                className="flex size-10 items-center justify-center rounded-full bg-governor-bay/10 text-governor-bay hover:bg-governor-bay hover:text-white transition-colors duration-300"
+                className="flex size-10 items-center justify-center rounded-full bg-muted text-foreground hover:bg-muted/80 transition-colors duration-300"
               >
                 <FaLinkedin />
               </a>
               <a
                 href="#"
-                className="flex size-10 items-center justify-center rounded-full bg-governor-bay/10 text-governor-bay hover:bg-governor-bay hover:text-white transition-colors duration-300"
+                className="flex size-10 items-center justify-center rounded-full bg-muted text-foreground hover:bg-muted/80 transition-colors duration-300"
               >
                 <FaTwitter />
               </a>
@@ -100,17 +100,17 @@ export function Team4() {
               />
             </div>
             <h3 className="mb-1 text-xl font-bold md:text-2xl">Emily Rodriguez</h3>
-            <p className="mb-4 text-french-gray">Marketing Director</p>
+            <p className="mb-4 text-muted-foreground">Marketing Director</p>
             <div className="flex gap-4">
               <a
                 href="#"
-                className="flex size-10 items-center justify-center rounded-full bg-governor-bay/10 text-governor-bay hover:bg-governor-bay hover:text-white transition-colors duration-300"
+                className="flex size-10 items-center justify-center rounded-full bg-muted text-foreground hover:bg-muted/80 transition-colors duration-300"
               >
                 <FaLinkedin />
               </a>
               <a
                 href="#"
-                className="flex size-10 items-center justify-center rounded-full bg-governor-bay/10 text-governor-bay hover:bg-governor-bay hover:text-white transition-colors duration-300"
+                className="flex size-10 items-center justify-center rounded-full bg-muted text-foreground hover:bg-muted/80 transition-colors duration-300"
               >
                 <FaTwitter />
               </a>

--- a/src/cnd-app/about-us/components/Team8.jsx
+++ b/src/cnd-app/about-us/components/Team8.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { BiLogoLinkedinSquare } from "react-icons/bi";
+import { Card, CardContent } from "../../../components/ui/card";
 import STimage from '../../../assets/st.jpg';
 import OKimage from '../../../assets/ok.jpeg';
 import KSimage from '../../../assets/ks.jpg';
@@ -7,22 +8,22 @@ import EEimage from '../../../assets/ee.jpg';
 
 export function Team8() {
   return (
-    <section className="px-[5%] py-16 md:py-20 lg:py-24 relative overflow-hidden bg-gradient-to-br from-slate-50 to-white">
+    <section className="px-[5%] py-16 md:py-20 lg:py-24 relative overflow-hidden bg-muted">
       {/* Background decorative elements */}
-      <div className="absolute -top-20 -right-20 w-64 h-64 bg-gradient-to-r from-emerald-400/5 to-blue-400/5 rounded-full blur-3xl"></div>
-      <div className="absolute bottom-10 -left-20 w-80 h-80 bg-gradient-to-r from-blue-400/5 to-purple-400/5 rounded-full blur-3xl"></div>
+      <div className="absolute -top-20 -right-20 w-64 h-64 bg-muted rounded-full blur-3xl"></div>
+      <div className="absolute bottom-10 -left-20 w-80 h-80 bg-muted rounded-full blur-3xl"></div>
       
       <div className="container relative z-10">
         {/* Header Section */}
         <div className="mb-12 max-w-3xl md:mb-18 lg:mb-20 text-center mx-auto">
-          <div className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-emerald-50 to-blue-50 border border-emerald-200/50 rounded-full text-sm font-medium text-emerald-700 shadow-sm backdrop-blur-sm mb-6">
+          <div className="inline-flex items-center px-4 py-2 bg-muted border rounded-full text-sm font-medium text-foreground shadow-sm mb-6">
             <span className="w-2 h-2 bg-emerald-400 rounded-full mr-2 animate-pulse"></span>
             Meet the Team ⚡
           </div>
-          <h2 className="text-4xl leading-[1.2] font-bold md:text-5xl lg:text-6xl bg-gradient-to-r from-emerald-600 to-blue-600 bg-clip-text text-transparent mb-6">
+          <h2 className="text-4xl leading-[1.2] font-bold md:text-5xl lg:text-6xl text-foreground mb-6">
             Our Passionate Team
           </h2>
-          <p className="text-lg text-gray-700 leading-relaxed">
+          <p className="text-lg text-muted-foreground leading-relaxed">
             Meet the dedicated individuals behind our mission to revolutionize EV charging through community connection.
           </p>
         </div>
@@ -30,96 +31,96 @@ export function Team8() {
         {/* Team Grid */}
         <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4 md:gap-10">
           {/* Saad Taslaq */}
-          <div className="group rounded-2xl bg-gradient-to-r from-white/80 to-emerald-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-2 overflow-hidden">
+          <Card className="group overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-2">
             <div className="relative overflow-hidden">
               <img
                 src={STimage}
                 alt="Saad Taslaq"
                 className="w-full h-64 object-cover group-hover:scale-105 transition-transform duration-500"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent group-hover:from-black/50 transition-all duration-300"></div>
+              <div className="absolute inset-0 bg-black/40 group-hover:bg-black/50 transition-all duration-300"></div>
             </div>
-            <div className="p-6">
-              <h3 className="text-xl font-bold text-gray-800 mb-4">Saad Taslaq</h3>
+            <CardContent className="p-6">
+              <h3 className="text-xl font-bold text-foreground mb-4">Saad Taslaq</h3>
               <div className="flex justify-center">
-                <a 
+                <a
                   href="https://www.linkedin.com/in/saadtaslaq?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app"
-                  className="size-10 rounded-full bg-gradient-to-r from-blue-500/20 to-blue-600/20 backdrop-blur-sm border border-white/30 flex items-center justify-center text-blue-600 hover:from-blue-500/30 hover:to-blue-600/30 hover:scale-110 transition-all duration-300 shadow-lg"
+                  className="size-10 rounded-full bg-muted border flex items-center justify-center text-foreground hover:scale-110 transition-all duration-300 shadow-lg"
                 >
                   <BiLogoLinkedinSquare className="size-5" />
                 </a>
               </div>
-            </div>
-          </div>
+            </CardContent>
+          </Card>
 
           {/* Eltayeb Elsunni */}
-          <div className="group rounded-2xl bg-gradient-to-r from-white/80 to-blue-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-2 overflow-hidden">
+          <Card className="group overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-2">
             <div className="relative overflow-hidden">
               <img
                 src={EEimage}
                 alt="Eltayeb Elsunni"
                 className="w-full h-64 object-cover group-hover:scale-105 transition-transform duration-500"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent group-hover:from-black/50 transition-all duration-300"></div>
+              <div className="absolute inset-0 bg-black/40 group-hover:bg-black/50 transition-all duration-300"></div>
             </div>
-            <div className="p-6">
-              <h3 className="text-xl font-bold text-gray-800 mb-4">Eltayeb Elsunni</h3>
+            <CardContent className="p-6">
+              <h3 className="text-xl font-bold text-foreground mb-4">Eltayeb Elsunni</h3>
               <div className="flex justify-center">
-                <a 
+                <a
                   href="https://www.linkedin.com/in/eltayebelsunni?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app"
-                  className="size-10 rounded-full bg-gradient-to-r from-blue-500/20 to-blue-600/20 backdrop-blur-sm border border-white/30 flex items-center justify-center text-blue-600 hover:from-blue-500/30 hover:to-blue-600/30 hover:scale-110 transition-all duration-300 shadow-lg"
+                  className="size-10 rounded-full bg-muted border flex items-center justify-center text-foreground hover:scale-110 transition-all duration-300 shadow-lg"
                 >
                   <BiLogoLinkedinSquare className="size-5" />
                 </a>
               </div>
-            </div>
-          </div>
+            </CardContent>
+          </Card>
 
           {/* Kyle Steele */}
-          <div className="group rounded-2xl bg-gradient-to-r from-white/80 to-purple-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-2 overflow-hidden">
+          <Card className="group overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-2">
             <div className="relative overflow-hidden">
               <img
                 src={KSimage}
                 alt="Kyle Steele"
                 className="w-full h-64 object-cover group-hover:scale-105 transition-transform duration-500"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent group-hover:from-black/50 transition-all duration-300"></div>
+              <div className="absolute inset-0 bg-black/40 group-hover:bg-black/50 transition-all duration-300"></div>
             </div>
-            <div className="p-6">
-              <h3 className="text-xl font-bold text-gray-800 mb-4">Kyle Steele</h3>
+            <CardContent className="p-6">
+              <h3 className="text-xl font-bold text-foreground mb-4">Kyle Steele</h3>
               <div className="flex justify-center">
-                <a 
+                <a
                   href="https://www.linkedin.com/in/kyle-steele-6832ba174?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app"
-                  className="size-10 rounded-full bg-gradient-to-r from-blue-500/20 to-blue-600/20 backdrop-blur-sm border border-white/30 flex items-center justify-center text-blue-600 hover:from-blue-500/30 hover:to-blue-600/30 hover:scale-110 transition-all duration-300 shadow-lg"
+                  className="size-10 rounded-full bg-muted border flex items-center justify-center text-foreground hover:scale-110 transition-all duration-300 shadow-lg"
                 >
                   <BiLogoLinkedinSquare className="size-5" />
                 </a>
               </div>
-            </div>
-          </div>
+            </CardContent>
+          </Card>
 
           {/* Omar Khan */}
-          <div className="group rounded-2xl bg-gradient-to-r from-white/80 to-teal-50/80 backdrop-blur-sm border border-white/30 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-2 overflow-hidden">
+          <Card className="group overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-2">
             <div className="relative overflow-hidden">
               <img
                 src={OKimage}
                 alt="Omar Khan"
                 className="w-full h-64 object-cover group-hover:scale-105 transition-transform duration-500"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent group-hover:from-black/50 transition-all duration-300"></div>
+              <div className="absolute inset-0 bg-black/40 group-hover:bg-black/50 transition-all duration-300"></div>
             </div>
-            <div className="p-6">
-              <h3 className="text-xl font-bold text-gray-800 mb-4">Omar Khan</h3>
+            <CardContent className="p-6">
+              <h3 className="text-xl font-bold text-foreground mb-4">Omar Khan</h3>
               <div className="flex justify-center">
-                <a 
+                <a
                   href="https://www.linkedin.com/in/omar-khan-ecse?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app"
-                  className="size-10 rounded-full bg-gradient-to-r from-blue-500/20 to-blue-600/20 backdrop-blur-sm border border-white/30 flex items-center justify-center text-blue-600 hover:from-blue-500/30 hover:to-blue-600/30 hover:scale-110 transition-all duration-300 shadow-lg"
+                  className="size-10 rounded-full bg-muted border flex items-center justify-center text-foreground hover:scale-110 transition-all duration-300 shadow-lg"
                 >
                   <BiLogoLinkedinSquare className="size-5" />
                 </a>
               </div>
-            </div>
-          </div>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace gradient-heavy sections with muted backgrounds
- adopt shadcn Button and Card components across about-us pages
- standardize typography to text-foreground and text-muted-foreground

## Testing
- `npm test -- --watch=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden for lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a0395af08330bfade05948beb395